### PR TITLE
update nfg_ui to 0.10 to capture browser 2.X upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     nfg_onboarder (0.0.3)
       decent_exposure
       haml
-      nfg_ui (~> 0.9)
+      nfg_ui (~> 0.10)
       rails (~> 5.0)
       reform
       simple_form
@@ -63,8 +63,8 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
-    browser (1.1.0)
-    builder (3.2.3)
+    browser (2.7.1)
+    builder (3.2.4)
     capybara (3.9.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -130,10 +130,10 @@ GEM
     minitest (5.13.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
-    nfg_ui (0.9.25.1)
+    nfg_ui (0.10)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
-      browser (~> 1.1)
+      browser (~> 2.7.1)
       coffee-script (~> 2.4)
       font-awesome-rails (~> 4.7)
       inky-rb (~> 1.3.7)
@@ -235,7 +235,7 @@ GEM
       thor (~> 0.14)
     shoulda-matchers (4.0.0.rc1)
       activesupport (>= 4.2.0)
-    simple_form (4.1.0)
+    simple_form (5.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
     sprockets (3.7.2)
@@ -256,7 +256,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    wicked (1.3.3)
+    wicked (1.3.4)
       railties (>= 3.0.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     minitest (5.13.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
-    nfg_ui (0.10)
+    nfg_ui (0.10.1)
       autoprefixer-rails (= 9.4.9)
       bootstrap (= 4.3.1)
       browser (~> 2.7.1)

--- a/nfg_onboarder.gemspec
+++ b/nfg_onboarder.gemspec
@@ -45,6 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'wicked'
   spec.add_dependency 'decent_exposure'
   spec.add_dependency 'haml'
-  spec.add_dependency 'nfg_ui', '~> 0.9'
+  spec.add_dependency 'nfg_ui', '~> 0.10'
   spec.add_dependency 'simple_form'
 end


### PR DESCRIPTION
Brings nfG_ui to 0.10 in nfg_onboarder for rails_5 branch