### PR TITLE
supply partial render for top of the page

### DIFF
--- a/app/views/layouts/nfg_ui/onboarding.html.haml
+++ b/app/views/layouts/nfg_ui/onboarding.html.haml
@@ -9,6 +9,8 @@
     = javascript_include_tag "nfg_onboarder/application", "data-turbolinks-track" => "reload"
     = csrf_meta_tags
   %body{ class: "#{controller_path.gsub('/', '-')} #{try(:step).try(:to_s)}" }
+    -# Allow host app to supply a partial for opening the page.
+    = render(partial: 'shared/after_opening_body_alert') rescue nil
     = yield :after_opening_body
     = yield
 


### PR DESCRIPTION
rescues nil for when host app does not have the partial