### PR TITLE
Feature/dm 8657 move preview and send test email on build step to decrease height of top bar

### DIFF
--- a/app/views/onboarding/nfg_ui/_high_level_navigation.html.haml
+++ b/app/views/onboarding/nfg_ui/_high_level_navigation.html.haml
@@ -2,10 +2,11 @@
 - next_step_confirmation = local_assigns[:next_step_confirmation]
 
 -# button locals
-- disable_next_button = false if local_assigns[:disable_next_button].nil?
 - back_button_text = local_assigns[:back_button_text]
 - submit_button_text = local_assigns[:submit_button_text]
 - submit_button_icon = local_assigns[:submit_button_icon]
+- disable_submit_button = false if local_assigns[:disable_submit_button].nil?
+- hide_submit_button = false if local_assigns[:hide_submit_button].nil?
 
 -# Fallback presenter
 - presenter = NfgOnboarder::HighLevelNavigationBarPresenter.new(onboarding_session, self) if local_assigns[:presenter].nil?
@@ -21,11 +22,11 @@
           = ui.nfg :step, presenter.step_status(step), step: i, href: presenter.href(step, path: wizard_path(step)), describe: "#{step}-step", icon: presenter.step_icon(step) do
             = presenter.step_body(step)
     .col-6.col-lg.text-right.d-none.d-lg-block
-      = ui.nfg :button, :lg, *[:submit, (:disabled if disable_next_button)], body: submit_button_text.html_safe, icon: submit_button_icon, class: 'flex-fill', confirm: next_step_confirmation, disable_with: ui.nfg(:icon, :loader)
+      = ui.nfg :button, :lg, *[:submit, (:disabled if disable_submit_button)], body: submit_button_text.html_safe, icon: submit_button_icon, class: 'flex-fill', confirm: next_step_confirmation, disable_with: ui.nfg(:icon, :loader), render_unless: hide_submit_button
 
 .builder-nav-sm
   .row
     .col
       = ui.nfg :button, :lg, :block, :secondary, :outlined, href: previous_wizard_path, body: back_button_text.html_safe, left_icon: 'caret-left', disable_with: ui.nfg(:icon, :loader), render_unless: presenter.render_previous_button_unless?, describe: 'previous-button'
     .col
-      = ui.nfg :button, :lg, :block, *[:submit, (:disabled if disable_next_button)], body: submit_button_text.html_safe, icon: submit_button_icon, class: 'flex-fill', confirm: next_step_confirmation, disable_with: ui.nfg(:icon, :loader)
+      = ui.nfg :button, :lg, :block, *[:submit, (:disabled if disable_submit_button)], body: submit_button_text.html_safe, icon: submit_button_icon, class: 'flex-fill', confirm: next_step_confirmation, disable_with: ui.nfg(:icon, :loader)

--- a/app/views/onboarding/nfg_ui/_masthead.html.haml
+++ b/app/views/onboarding/nfg_ui/_masthead.html.haml
@@ -10,10 +10,11 @@
       = ui.nfg :typeface, :muted, caption: presenter.title_bar_caption, class: 'mb-0'
       = ui.nfg :typeface, :white, heading: presenter.title_bar_title, render_if: render_title
 
-    - if show_exit_button
-      .col-auto
+    .col-auto
+      = yield :masthead_links
+
+      - if show_exit_button
         - if first_step || exit_without_saving
           = ui.nfg :button, :link, href: exit_without_saving_path, body: t('title_bar.buttons.exit', scope: locale_namespace), class: 'my-1 text-light', id: 'exit_button'
-
         - else
           = ui.nfg :button, :link, href: exit_path, id: 'save_and_exit',  body: t('title_bar.buttons.save_and_exit', scope: locale_namespace), class: 'my-1 text-light'

--- a/app/views/onboarding/nfg_ui/_sub_layout.html.haml
+++ b/app/views/onboarding/nfg_ui/_sub_layout.html.haml
@@ -15,6 +15,8 @@
 - back_button_text = t('back', scope: locale_namespace + [step, :button], default: 'Prev') if local_assigns[:back_button_text].nil?
 - submit_button_text = t('submit', scope: locale_namespace + [step, :button], default: 'Next') if local_assigns[:submit_button_text].nil?
 - submit_button_icon = 'caret-right' if local_assigns[:submit_button_icon].nil?
+- disable_submit_button = false if local_assigns[:disable_submitt_button].nil?
+- hide_submit_button = false if local_assigns[:hide_submit_button].nil?
 - framed = true if local_assigns[:framed].nil? # controls whether the page is displayed with a border
 - hide_navigation_bar = false if local_assigns[:hide_navigation_bar].nil?
 - masthead_presenter ||= nil
@@ -23,7 +25,7 @@
   = render partial: "onboarding/nfg_ui/masthead", locals: { presenter: masthead_presenter, show_exit_button: show_exit_button, exit_without_saving: exit_without_saving? }
 
   - unless hide_navigation_bar
-    = render partial: 'onboarding/nfg_ui/high_level_navigation', locals: { back_button_text: back_button_text, submit_button_text: submit_button_text, submit_button_icon: submit_button_icon, next_step_confirmation: next_step_confirmation }
+    = render partial: 'onboarding/nfg_ui/high_level_navigation', locals: { back_button_text: back_button_text, submit_button_text: submit_button_text, submit_button_icon: submit_button_icon, disable_submit_button: disable_submit_button, hide_submit_button: hide_submit_button, next_step_confirmation: next_step_confirmation }
 
   .builder-container
     - if framed

--- a/spec/views/onboarding/nfg_ui/_high_level_navigation.html.haml_spec.rb
+++ b/spec/views/onboarding/nfg_ui/_high_level_navigation.html.haml_spec.rb
@@ -5,7 +5,8 @@ require 'wicked'
 RSpec.describe 'onboarding/nfg_ui/_high_level_navigation.html.haml', type: :view do
   # Locals
   let(:next_step_confirmation) { nil }
-  let(:disable_next_button) { nil }
+  let(:disable_submit_button) { nil }
+  let(:hide_submit_button) { nil }
   let(:back_button_text) { '' }
   let(:submit_button_text) { '' }
   let(:onboarding_session) { FactoryBot.create(:onboarding_session) }
@@ -41,7 +42,7 @@ RSpec.describe 'onboarding/nfg_ui/_high_level_navigation.html.haml', type: :view
     allow(presenter).to receive(:render_previous_button_unless?).and_return(render_previous_button_unless)
   end
 
-  subject { render partial: 'onboarding/nfg_ui/high_level_navigation', locals: { next_step_confirmation: next_step_confirmation, disable_next_button: disable_next_button, back_button_text: back_button_text, submit_button_text: submit_button_text, presenter: presenter } }
+  subject { render partial: 'onboarding/nfg_ui/high_level_navigation', locals: { next_step_confirmation: next_step_confirmation, disable_submit_button: disable_submit_button, hide_submit_button: hide_submit_button, back_button_text: back_button_text, submit_button_text: submit_button_text, presenter: presenter } }
 
   describe 'the steps in the step nav' do
     it 'lists a nav item for each step' do


### PR DESCRIPTION
This PR allows for extra links using a yield block to be added to the masthead. This is used on email blast build onboarder:
![Screen Shot 2021-07-27 at 3 14 48 PM](https://user-images.githubusercontent.com/16546623/127214145-66339cb3-05c2-456e-8746-8cc598fc9af0.png)

I've also added a param to hide the submit button in the navigation. This is used on the email blast review step, because there are multiple primary CTA's and having a third at the same visual weight is not ideal.
![Screen Shot 2021-07-27 at 3 15 10 PM](https://user-images.githubusercontent.com/16546623/127214194-3377b0f4-7597-4ead-a3e5-a7e4d65340ab.png)


DM PR: https://github.com/network-for-good/donor_management/pull/2404
Onboarder PR: https://github.com/network-for-good/nfg_onboarder/pull/68
NFG UI PR: https://github.com/network-for-good/nfg_ui/pull/119