### PR TITLE
feature/PSTWO-18294_add_button_id_on_next_button_in_nfg_ui_onboarder_version

### DIFF
--- a/app/views/onboarding/nfg_ui/_high_level_navigation.html.haml
+++ b/app/views/onboarding/nfg_ui/_high_level_navigation.html.haml
@@ -14,7 +14,7 @@
 .builder-nav
   .row.align-items-center.justify-content-between
     .col-6.col-lg.d-none.d-lg-block
-      = ui.nfg :button, :lg, :secondary, :outlined, href: previous_wizard_path, body: back_button_text.html_safe, left_icon: 'caret-left', class: 'flex-fill', disable_with: ui.nfg(:icon, :loader), render_unless: presenter.render_previous_button_unless?, describe: 'previous-button'
+      = ui.nfg :button, :lg, :secondary, :outlined, href: previous_wizard_path, body: back_button_text.html_safe, id: 'prev_step', class: 'flex-fill', describe: 'previous-button', disable_with: ui.nfg(:icon, :loader), render_unless: presenter.render_previous_button_unless?
     .col-12.col-lg-8.mx-auto
       = ui.nfg :steps, describe: 'nav-steps' do
         - controller.wizard_steps.each_with_index do |step, i|
@@ -22,7 +22,7 @@
           = ui.nfg :step, presenter.step_status(step), step: i, href: presenter.href(step, path: wizard_path(step)), describe: "#{step}-step", icon: presenter.step_icon(step) do
             = presenter.step_body(step)
     .col-6.col-lg.text-right.d-none.d-lg-block
-      = ui.nfg :button, :lg, *[:submit, (:disabled if disable_submit_button)], body: submit_button_text.html_safe, icon: submit_button_icon, class: 'flex-fill', confirm: next_step_confirmation, disable_with: ui.nfg(:icon, :loader), render_unless: hide_submit_button
+      = ui.nfg :button, :lg, *[:submit, (:disabled if disable_submit_button)], body: submit_button_text.html_safe, icon: submit_button_icon, id: 'next_step', class: 'flex-fill', describe: 'next-button', disable_with: ui.nfg(:icon, :loader), confirm: next_step_confirmation, render_unless: hide_submit_button
 
 .builder-nav-sm
   .row

--- a/app/views/onboarding/nfg_ui/_sub_layout.html.haml
+++ b/app/views/onboarding/nfg_ui/_sub_layout.html.haml
@@ -14,8 +14,8 @@
 - next_step_confirmation = nil if local_assigns[:next_step_confirmation].nil? # pass in a confirmation prompt on submit
 - back_button_text = t('back', scope: locale_namespace + [step, :button], default: 'Prev') if local_assigns[:back_button_text].nil?
 - submit_button_text = t('submit', scope: locale_namespace + [step, :button], default: 'Next') if local_assigns[:submit_button_text].nil?
-- submit_button_icon = 'caret-right' if local_assigns[:submit_button_icon].nil?
-- disable_submit_button = false if local_assigns[:disable_submitt_button].nil?
+- submit_button_icon = false if local_assigns[:submit_button_icon].nil?
+- disable_submit_button = false if local_assigns[:disable_submit_button].nil?
 - hide_submit_button = false if local_assigns[:hide_submit_button].nil?
 - framed = true if local_assigns[:framed].nil? # controls whether the page is displayed with a border
 - hide_navigation_bar = false if local_assigns[:hide_navigation_bar].nil?


### PR DESCRIPTION
DM PR: https://github.com/network-for-good/donor_management/pull/2493
FP PR: https://github.com/network-for-good/Givecorps-site/pull/2138
Onboarder PR: https://github.com/network-for-good/nfg_onboarder/pull/78

adds ids to buttons and removes default icons on prev/next buttons