### PR TITLE
fix(security): SCA upgrades — nokogiri (nfg_onboarder)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'rails', '~> 7.2.0'
 gem 'bundler', '~> 2.5'
 gem 'sprockets', "~> 3.7"
+gem "nokogiri", "1.18.9"
 
 group :test do
   gem 'reform-rails', '~> 0.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
       sass-rails (~> 6.0)
       select2-rails (~> 4.0)
     nio4r (2.7.4)
-    nokogiri (1.18.8)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     observer (0.1.2)
@@ -366,6 +366,7 @@ DEPENDENCIES
   matrix
   mutex_m
   nfg_onboarder!
+  nokogiri (= 1.18.9)
   ostruct
   pry
   pry-rails


### PR DESCRIPTION
## Security: SCA dependency upgrades

Upgrades 1 vulnerable dependency identified via Snyk SCA scanning.

### Changes

| Library | Before | After | CVEs fixed |
|---------|--------|-------|------------|
| nokogiri | 1.18.8 | 1.18.9 | 3 |

### Linked Jira tickets

- [NFG-3743](https://bonterra.atlassian.net/browse/NFG-3743) — nokogiri upgrade (SLA: 2026-07-31)

### References

- Snyk Project: https://app.snyk.io/org/networkforgood/project/dfcfd198-79e8-4393-9c35-f92e6438cc9c#issue-SNYK-RUBY-NOKOGIRI

### Note on this ticket's history

This finding was previously closed as a false positive based on a corrected target version that was actually a downgrade from the installed version (a version-selection bug in that run). Live Snyk still reports this finding open; the real fix on the installed branch is 1.18.9. nokogiri is transitive-only here, so this adds an explicit Gemfile pin. Jira comment being corrected separately.

---
*AppSec-generated. Questions? Ping #appsec.*

[NFG-3743]: https://bonterra.atlassian.net/browse/NFG-3743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ